### PR TITLE
fix: close body after response

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -62,6 +62,7 @@ func (client Client) Do(method string, url string, headers RequestHeaders, body 
 	if err != nil {
 		return nil, ResponseHeaders{}, err
 	}
+	defer resp.Body.Close()
 
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Response bodies in Go must be closed if the error returned is nil:
```go
// If the returned error is nil, the Response will contain a non-nil
// Body which the user is expected to close. If the Body is not both
// read to EOF and closed, the Client's underlying RoundTripper
// (typically Transport) may not be able to re-use a persistent TCP
// connection to the server for a subsequent "keep-alive" request.
```