### PR TITLE
feat: get customer by query params

### DIFF
--- a/customers.go
+++ b/customers.go
@@ -188,16 +188,13 @@ func (c customerRepository) GetByQuery(fields []string, query string) (shopify.C
 
 	body, _, err := c.client.Get(url, nil)
 	if err != nil {
-		switch err.(type) {
 		// TODO This ErrHTTP feels like bloat now. Can probably simplify the http work
-		case http.ErrHTTP:
-			shopifyError := err.(http.ErrHTTP)
-			switch shopifyError.Code {
-			case httpCode.StatusNotFound:
-				return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query)
-			}
+		switch err.(http.ErrHTTP).Code {
+		case httpCode.StatusNotFound:
+			return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query)
+		default:
+			return shopify.Customers{}, err
 		}
-		return shopify.Customers{}, err
 	}
 
 	var responseDTO struct {

--- a/customers.go
+++ b/customers.go
@@ -190,7 +190,7 @@ func (c customerRepository) GetByQuery(fields []string, query shopify.CustomerSe
 	if err != nil {
 		switch err.(http.ErrHTTP).Code {
 		case httpCode.StatusNotFound:
-			return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query.String())
+			return shopify.Customers{}, err
 		default:
 			return shopify.Customers{}, err
 		}
@@ -203,10 +203,6 @@ func (c customerRepository) GetByQuery(fields []string, query shopify.CustomerSe
 	err = json.Unmarshal(body, &responseDTO)
 	if err != nil {
 		return shopify.Customers{}, err
-	}
-
-	if responseDTO.Customers[0].ID == 0 {
-		return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query.String())
 	}
 
 	return responseDTO.Customers.ToShopify(), nil

--- a/customers.go
+++ b/customers.go
@@ -188,7 +188,6 @@ func (c customerRepository) GetByQuery(fields []string, query string) (shopify.C
 
 	body, _, err := c.client.Get(url, nil)
 	if err != nil {
-		// TODO This ErrHTTP feels like bloat now. Can probably simplify the http work
 		switch err.(http.ErrHTTP).Code {
 		case httpCode.StatusNotFound:
 			return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query)

--- a/customers.go
+++ b/customers.go
@@ -183,14 +183,14 @@ func (c customerRepository) Update(customer shopify.Customer) (shopify.Customer,
 	return response.Customer.ToShopify(), nil
 }
 
-func (c customerRepository) GetByQuery(fields []string, query string) (shopify.Customers, error) {
-	url := c.createURL(fmt.Sprintf("customers/search.json?fields=%v&query=%v", strings.Join(fields, ","), query))
+func (c customerRepository) GetByQuery(fields []string, query shopify.CustomerSearchQuery) (shopify.Customers, error) {
+	url := c.createURL(fmt.Sprintf("customers/search.json?fields=%v&query=%s", strings.Join(fields, ","), query.String()))
 
 	body, _, err := c.client.Get(url, nil)
 	if err != nil {
 		switch err.(http.ErrHTTP).Code {
 		case httpCode.StatusNotFound:
-			return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query)
+			return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query.String())
 		default:
 			return shopify.Customers{}, err
 		}
@@ -206,7 +206,7 @@ func (c customerRepository) GetByQuery(fields []string, query string) (shopify.C
 	}
 
 	if responseDTO.Customers[0].ID == 0 {
-		return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query)
+		return shopify.Customers{}, shopify.NewErrCustomerSearchNotFound(query.String())
 	}
 
 	return responseDTO.Customers.ToShopify(), nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/MOHC-LTD/httpshopify
 go 1.16
 
 require (
-	github.com/MOHC-LTD/shopify v1.30.0
+	github.com/MOHC-LTD/shopify v1.31.0
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/MOHC-LTD/shopify v1.29.0 h1:r3xRdEHxxv+Y1yRNf0cPGNDrBmUtvk/Z5/+ta4Xow2w=
-github.com/MOHC-LTD/shopify v1.29.0/go.mod h1:3+7WdQJy9OI9GSa2vbh+WM4QHJDohehOfZYpOSbUgyg=
-github.com/MOHC-LTD/shopify v1.30.0 h1:SCYQ+gpl9ksEz6XpcBKSuvlpw2fCjCqGrtOLSzAXMyQ=
-github.com/MOHC-LTD/shopify v1.30.0/go.mod h1:3+7WdQJy9OI9GSa2vbh+WM4QHJDohehOfZYpOSbUgyg=
+github.com/MOHC-LTD/shopify v1.31.0 h1:SW2HtHVefJB4EIeAtVnnzgcMO3OdvEwDzk1lfh3YtQo=
+github.com/MOHC-LTD/shopify v1.31.0/go.mod h1:3+7WdQJy9OI9GSa2vbh+WM4QHJDohehOfZYpOSbUgyg=
 github.com/jaswdr/faker v1.15.0 h1:wcEVaPKFE53NvdT4fl+w3b0IXdefp1Yk0BdBs0APCoA=
 github.com/jaswdr/faker v1.15.0/go.mod h1:x7ZlyB1AZqwqKZgyQlnqEG8FDptmHlncA5u2zY/yi6w=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=


### PR DESCRIPTION
This addition allows the retrieval of customer specific fields based on specified search query.

This functionality will help achieving the delete customer address feature since we now have to retrieve the customerID based on the patientID, which is stored in the Customer Tags.

[Shopify REST](https://shopify.dev/api/admin-rest/2022-10/resources/customer#get-customers-search?query=email:*@mail.example.com-examples)