### PR TITLE
feat: rate limit updates

### DIFF
--- a/rates.go
+++ b/rates.go
@@ -20,15 +20,15 @@ func RateLimitDefault() http.Option {
 // RateLimitPlus builds the rate limit for the rest API of a Shopify plus store.
 /*
 	This limit is as follows:
-	LeakRate: 4/second
-	BucketSize: 80 requests/app/store
+	LeakRate: 20/second
+	BucketSize: 400 requests/app/store
 
 	Source: https://shopify.dev/api/usage/rate-limits.
 */
 func RateLimitPlus() http.Option {
 	return http.WithRateLimit(
-		4,
-		80,
+		20,
+		400,
 	)
 }
 


### PR DESCRIPTION
Shopify has [recently](https://shopify.dev/changelog/increased-admin-api-rate-limits-for-shopify-plus) updated their [rate limits for Plus stores](https://shopify.dev/docs/api/usage/rate-limits#rest-admin-api-rate-limits) using the REST Admin API:
- 20 requests per second
- 400 request bucket size

This rate limit update is live and effective on all Shopify API versions