### PR TITLE
feat: fulfillment updates

### DIFF
--- a/addresses.go
+++ b/addresses.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // AddressDTO represents a Shopify Address in HTTP requests and responses
 type AddressDTO struct {

--- a/collections.go
+++ b/collections.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type collectionRepository struct {

--- a/collections_test.go
+++ b/collections_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests that collection cab be built correctly when date fields are not nil

--- a/customer-address.go
+++ b/customer-address.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type customerAddressRepository struct {

--- a/customers.go
+++ b/customers.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // CustomerDTO represents a Shopify customer in HTTP requests and responses

--- a/customers_test.go
+++ b/customers_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Tests customer can be built when date fields are not nil

--- a/discounts.go
+++ b/discounts.go
@@ -1,7 +1,7 @@
 package httpshopify
 
 import (
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // DiscountApplicationDTO represents a Shopify discount application in HTTP requests and responses

--- a/fulfillment-events.go
+++ b/fulfillment-events.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type fulfillmentEventRepository struct {

--- a/fulfillment-events_test.go
+++ b/fulfillment-events_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests that fulfillment event can be built correctly when date fields are not nil

--- a/fulfillment-orders.go
+++ b/fulfillment-orders.go
@@ -1,0 +1,153 @@
+package httpshopify
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/MOHC-LTD/httpshopify/internal/http"
+
+	"github.com/MOHC-LTD/shopify"
+)
+
+type fulfillmentOrderRepository struct {
+	client    http.Client
+	createURL func(endpoint string) string
+}
+
+func newFulfillmentOrderRepository(client http.Client, createURL func(endpoint string) string) fulfillmentOrderRepository {
+	return fulfillmentOrderRepository{
+		client,
+		createURL,
+	}
+}
+
+func (repository fulfillmentOrderRepository) Get(id int64) (shopify.FulfillmentOrder, error) {
+	url := repository.createURL(fmt.Sprintf("fulfillment_orders/%v.json", id))
+
+	respBody, _, err := repository.client.Get(url, nil)
+	if err != nil {
+		return shopify.FulfillmentOrder{}, err
+	}
+
+	response := struct {
+		FulfillmentOrder FulfillmentOrderDTO `json:"fulfillment_order"`
+	}{}
+
+	err = json.Unmarshal(respBody, &response)
+	if err != nil {
+		return shopify.FulfillmentOrder{}, err
+	}
+
+	return response.FulfillmentOrder.ToShopify(), nil
+}
+
+func (repository fulfillmentOrderRepository) List(orderID int64) (shopify.FulfillmentOrders, error) {
+	url := repository.createURL(fmt.Sprintf("orders/%v/fulfillment_orders.json", orderID))
+
+	respBody, _, err := repository.client.Get(url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	response := struct {
+		FulfillmentOrders []FulfillmentOrderDTO `json:"fulfillment_orders"`
+	}{}
+
+	err = json.Unmarshal(respBody, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	fulfillmentOrders := make(shopify.FulfillmentOrders, 0, len(response.FulfillmentOrders))
+	for _, dto := range response.FulfillmentOrders {
+		fulfillmentOrders = append(fulfillmentOrders, dto.ToShopify())
+	}
+
+	return fulfillmentOrders, nil
+}
+
+// FulfillmentOrderDTO represents a Shopify fulfillment order in HTTP requests and responses
+type FulfillmentOrderDTO struct {
+	ID                 int64                        `json:"id,omitempty"`
+	OrderID            int64                        `json:"order_id,omitempty"`
+	AssignedLocationID int64                        `json:"assigned_location_id,omitempty"`
+	Status             string                       `json:"status,omitempty"`
+	LineItems          FulfillmentOrderLineItemDTOs `json:"line_items,omitempty"`
+	CreatedAt          *time.Time                   `json:"created_at,omitempty"`
+	UpdatedAt          *time.Time                   `json:"updated_at,omitempty"`
+}
+
+// ToShopify converts the DTO to the Shopify equivalent
+func (dto FulfillmentOrderDTO) ToShopify() shopify.FulfillmentOrder {
+	createdAt := time.Time{}
+	if dto.CreatedAt != nil {
+		createdAt = *dto.CreatedAt
+	}
+
+	updatedAt := time.Time{}
+	if dto.UpdatedAt != nil {
+		updatedAt = *dto.UpdatedAt
+	}
+
+	return shopify.FulfillmentOrder{
+		ID:                 dto.ID,
+		OrderID:            dto.OrderID,
+		AssignedLocationID: dto.AssignedLocationID,
+		LineItems:          dto.LineItems.ToShopify(),
+		Status:             dto.Status,
+		CreatedAt:          createdAt,
+		UpdatedAt:          updatedAt,
+	}
+}
+
+// FulfillmentOrderLineItemDTO represents a Shopify fulfillment order in HTTP requests and responses
+type FulfillmentOrderLineItemDTO struct {
+	ID                  int64 `json:"id,omitempty"`
+	LineItemID          int64 `json:"line_item_id,omitempty"`
+	VariantID           int64 `json:"variant_id,omitempty"`
+	Quantity            int   `json:"quantity,omitempty"`
+	FulfillableQuantity int   `json:"fulfillable_quantity,omitempty"`
+}
+
+func (dto FulfillmentOrderLineItemDTO) ToShopify() shopify.FulfillmentOrderLineItem {
+	return shopify.FulfillmentOrderLineItem{
+		ID:                  dto.ID,
+		LineItemID:          dto.LineItemID,
+		VariantID:           dto.VariantID,
+		Quantity:            dto.Quantity,
+		FulfillableQuantity: dto.FulfillableQuantity,
+	}
+}
+
+// BuildFulfillmentOrderLineItemDTO converts a fulfillment order line item into a DTO equivalent
+func BuildFulfillmentOrderLineItemDTO(lineItem shopify.FulfillmentOrderLineItem) FulfillmentOrderLineItemDTO {
+	return FulfillmentOrderLineItemDTO{
+		ID:                  lineItem.ID,
+		Quantity:            lineItem.Quantity,
+		LineItemID:          lineItem.LineItemID,
+		VariantID:           lineItem.VariantID,
+		FulfillableQuantity: lineItem.FulfillableQuantity,
+	}
+}
+
+// FulfillmentOrderLineItemDTOs is a collection of fulfillment order line item DTOs
+type FulfillmentOrderLineItemDTOs []FulfillmentOrderLineItemDTO
+
+// ToShopify converts the DTOs to the Shopify equivalent
+func (dtos FulfillmentOrderLineItemDTOs) ToShopify() shopify.FulfillmentOrderLineItems {
+	lineItems := make(shopify.FulfillmentOrderLineItems, 0, len(dtos))
+	for _, dto := range dtos {
+		lineItems = append(lineItems, dto.ToShopify())
+	}
+	return lineItems
+}
+
+// BuildFulfillmentOrderLineItemDTOs converts many fulfillment order line items into a DTO equivalent
+func BuildFulfillmentOrderLineItemDTOs(lineItems []shopify.FulfillmentOrderLineItem) []FulfillmentOrderLineItemDTO {
+	dtos := make([]FulfillmentOrderLineItemDTO, 0, len(lineItems))
+	for _, lineItem := range lineItems {
+		dtos = append(dtos, BuildFulfillmentOrderLineItemDTO(lineItem))
+	}
+	return dtos
+}

--- a/fulfillment-orders.go
+++ b/fulfillment-orders.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type fulfillmentOrderRepository struct {

--- a/fulfillment-orders.go
+++ b/fulfillment-orders.go
@@ -23,7 +23,7 @@ func newFulfillmentOrderRepository(client http.Client, createURL func(endpoint s
 }
 
 func (repository fulfillmentOrderRepository) Get(id int64) (shopify.FulfillmentOrder, error) {
-	url := repository.createURL(fmt.Sprintf("fulfillment_orders/%v.json", id))
+	url := repository.createURL(fmt.Sprintf("fulfillment_orders/%d.json", id))
 
 	respBody, _, err := repository.client.Get(url, nil)
 	if err != nil {
@@ -43,7 +43,7 @@ func (repository fulfillmentOrderRepository) Get(id int64) (shopify.FulfillmentO
 }
 
 func (repository fulfillmentOrderRepository) List(orderID int64) (shopify.FulfillmentOrders, error) {
-	url := repository.createURL(fmt.Sprintf("orders/%v/fulfillment_orders.json", orderID))
+	url := repository.createURL(fmt.Sprintf("orders/%d/fulfillment_orders.json", orderID))
 
 	respBody, _, err := repository.client.Get(url, nil)
 	if err != nil {

--- a/fulfillment-orders_test.go
+++ b/fulfillment-orders_test.go
@@ -1,0 +1,50 @@
+package httpshopify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+)
+
+// Tests that fulfillment order can be built correctly when date fields are not nil
+func TestFulfillmentOrderDTO_ToShopify(t *testing.T) {
+	createdAt := time.Now()
+	updatedAt := time.Now()
+
+	var fulfillmentOrderDTO = FulfillmentOrderDTO{
+		CreatedAt: &createdAt,
+		UpdatedAt: &updatedAt,
+	}
+
+	fulfillmentOrder := fulfillmentOrderDTO.ToShopify()
+
+	if !fulfillmentOrder.CreatedAt.Equal(createdAt) {
+		assertions.ValueAssertionFailure(t, createdAt, fulfillmentOrder.CreatedAt)
+	}
+
+	if !fulfillmentOrder.UpdatedAt.Equal(updatedAt) {
+		assertions.ValueAssertionFailure(t, updatedAt, fulfillmentOrder.UpdatedAt)
+	}
+}
+
+// Tests that fulfillment order can be built correctly when date fields are nil
+func TestFulfillmentOrderDTO_ToShopifyEmptyFields(t *testing.T) {
+	var createdAt *time.Time
+	var updatedAt *time.Time
+
+	var fulfillmentOrderDTO = FulfillmentOrderDTO{
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+
+	fulfillmentOrder := fulfillmentOrderDTO.ToShopify()
+
+	if !fulfillmentOrder.CreatedAt.IsZero() {
+		assertions.ValueAssertionFailure(t, createdAt, fulfillmentOrder.CreatedAt)
+	}
+
+	if !fulfillmentOrder.UpdatedAt.IsZero() {
+		assertions.ValueAssertionFailure(t, updatedAt, fulfillmentOrder.UpdatedAt)
+	}
+}

--- a/fulfillment-orders_test.go
+++ b/fulfillment-orders_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests that fulfillment order can be built correctly when date fields are not nil

--- a/fulfillments.go
+++ b/fulfillments.go
@@ -114,7 +114,9 @@ type FulfillmentDTO struct {
 	ID                          int64                            `json:"id,omitempty"`
 	OrderID                     int64                            `json:"order_id,omitempty"`
 	TrackingCompany             string                           `json:"tracking_company,omitempty"`
+	TrackingNumber              string                           `json:"tracking_number,omitempty"`
 	TrackingNumbers             []string                         `json:"tracking_numbers,omitempty"`
+	TrackingURL                 string                           `json:"tracking_url,omitempty"`
 	TrackingURLs                []string                         `json:"tracking_urls,omitempty"`
 	Status                      string                           `json:"status,omitempty"`
 	CreatedAt                   *time.Time                       `json:"created_at,omitempty"`
@@ -143,7 +145,9 @@ func (dto FulfillmentDTO) ToShopify() shopify.Fulfillment {
 		ID:              dto.ID,
 		OrderID:         dto.OrderID,
 		TrackingCompany: dto.TrackingCompany,
+		TrackingNumber:  dto.TrackingNumber,
 		TrackingNumbers: dto.TrackingNumbers,
+		TrackingURL:     dto.TrackingURL,
 		TrackingURLs:    dto.TrackingURLs,
 		Status:          dto.Status,
 		CreatedAt:       createdAt,
@@ -171,7 +175,9 @@ func BuildFulfilmentDTO(fulfillment shopify.Fulfillment) FulfillmentDTO {
 		ID:              fulfillment.ID,
 		OrderID:         fulfillment.OrderID,
 		TrackingCompany: fulfillment.TrackingCompany,
+		TrackingNumber:  fulfillment.TrackingNumber,
 		TrackingNumbers: fulfillment.TrackingNumbers,
+		TrackingURL:     fulfillment.TrackingURL,
 		TrackingURLs:    fulfillment.TrackingURLs,
 		Status:          fulfillment.Status,
 		NotifyCustomer:  fulfillment.NotifyCustomer,
@@ -216,24 +222,14 @@ type TrackingInfoDTO struct {
 
 // BuildTrackingInfoDTO converts fulfillment tracking info into a DTO equivalent
 func BuildTrackingInfoDTO(fulfillment shopify.Fulfillment) *TrackingInfoDTO {
-	trackingNumber := ""
-	if len(fulfillment.TrackingNumbers) > 0 {
-		trackingNumber = fulfillment.TrackingNumbers[0]
-	}
-
-	trackingURL := ""
-	if len(fulfillment.TrackingURLs) > 0 {
-		trackingURL = fulfillment.TrackingURLs[0]
-	}
-
-	if trackingNumber == "" && trackingURL == "" && fulfillment.TrackingCompany == "" {
+	if fulfillment.TrackingNumber == "" && fulfillment.TrackingURL == "" && fulfillment.TrackingCompany == "" {
 		return nil
 	}
 
 	return &TrackingInfoDTO{
 		Company: fulfillment.TrackingCompany,
-		Number:  trackingNumber,
-		URL:     trackingURL,
+		Number:  fulfillment.TrackingNumber,
+		URL:     fulfillment.TrackingURL,
 	}
 }
 

--- a/fulfillments.go
+++ b/fulfillments.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type fulfillmentRepository struct {

--- a/fulfillments.go
+++ b/fulfillments.go
@@ -76,7 +76,7 @@ func (repository fulfillmentRepository) UpdateTracking(update shopify.Fulfillmen
 		return shopify.Fulfillment{}, err
 	}
 
-	url := repository.createURL(fmt.Sprintf("fulfillments/%v/update_tracking.json", update.ID))
+	url := repository.createURL(fmt.Sprintf("fulfillments/%d/update_tracking.json", update.ID))
 
 	respBody, _, err := repository.client.Post(url, body, nil)
 	if err != nil {
@@ -96,7 +96,7 @@ func (repository fulfillmentRepository) UpdateTracking(update shopify.Fulfillmen
 }
 
 func (repository fulfillmentRepository) Cancel(id int64) error {
-	url := repository.createURL(fmt.Sprintf("fulfillments/%v/cancel.json", id))
+	url := repository.createURL(fmt.Sprintf("fulfillments/%d/cancel.json", id))
 
 	_, _, err := repository.client.Post(url, nil, nil)
 	if err != nil {

--- a/fulfillments_test.go
+++ b/fulfillments_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Tests that fulfillment can be built correctly when date fields are not nil

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/MOHC-LTD/httpshopify
+module github.com/MOHC-LTD/httpshopify/v2
 
 go 1.16
 
 require (
-	github.com/MOHC-LTD/shopify v1.38.0
+	github.com/MOHC-LTD/shopify/v2 v2.0.0
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/MOHC-LTD/shopify v1.35.0 h1:zjrrhLbkKIPce+e+af1Ni7rmrpF2Wf6r43xkNEujfO0=
-github.com/MOHC-LTD/shopify v1.35.0/go.mod h1:3+7WdQJy9OI9GSa2vbh+WM4QHJDohehOfZYpOSbUgyg=
-github.com/MOHC-LTD/shopify v1.38.0 h1:FXrFF2An0qE84mKsFo67wZ9V0jkLlM/J+EWaF3OcDP4=
-github.com/MOHC-LTD/shopify v1.38.0/go.mod h1:3+7WdQJy9OI9GSa2vbh+WM4QHJDohehOfZYpOSbUgyg=
+github.com/MOHC-LTD/shopify/v2 v2.0.0 h1:MKNXnMWGbhEDmwZwLhkd2x1erAq5/ycY2BYQi6NaUa0=
+github.com/MOHC-LTD/shopify/v2 v2.0.0/go.mod h1:NH8yvZX6NgRexC38va3jNswUcRkvpea+E7ploSSoty0=
 github.com/jaswdr/faker v1.15.0 h1:wcEVaPKFE53NvdT4fl+w3b0IXdefp1Yk0BdBs0APCoA=
 github.com/jaswdr/faker v1.15.0/go.mod h1:x7ZlyB1AZqwqKZgyQlnqEG8FDptmHlncA5u2zY/yi6w=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 h1:Vv0JUPWTyeqUq42B2WJ1FeIDjjvGKoA2Ss+Ts0lAVbs=

--- a/images.go
+++ b/images.go
@@ -3,7 +3,7 @@ package httpshopify
 import (
 	"time"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // ImageDTO represents a Shopify Image in HTTP requests and responses

--- a/images_test.go
+++ b/images_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests image can be built when date fields are not nil

--- a/internal/slices/int64_test.go
+++ b/internal/slices/int64_test.go
@@ -4,9 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 
-	"github.com/MOHC-LTD/httpshopify/internal/slices"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/slices"
 )
 
 func TestJoinInt64(t *testing.T) {

--- a/inventory-levels.go
+++ b/inventory-levels.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type inventoryLevelRepository struct {

--- a/inventory-levels_test.go
+++ b/inventory-levels_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests inventory level can be built when date fields are not nil

--- a/line-items.go
+++ b/line-items.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // LineItemDTO represents a Shopify line item in HTTP requests and responses
 type LineItemDTO struct {

--- a/metafields.go
+++ b/metafields.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type metafieldRepository struct {

--- a/money.go
+++ b/money.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // PriceSetDTO represents a price set in Shopify HTTP requests and responses
 type PriceSetDTO struct {

--- a/orders.go
+++ b/orders.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/slices"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/slices"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type orderRepository struct {

--- a/orders_test.go
+++ b/orders_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Tests order can be built when date fields are not nil

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/MOHC-LTD/httpshopify"
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 func TestParseLinkHeader(t *testing.T) {

--- a/product-images.go
+++ b/product-images.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type productImagesRepository struct {

--- a/product-images_test.go
+++ b/product-images_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Tests product image can be built when date fields are not nil

--- a/products.go
+++ b/products.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
-	"github.com/MOHC-LTD/httpshopify/internal/slices"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/slices"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type productRepository struct {

--- a/products_test.go
+++ b/products_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
 )
 
 // Tests product can be built when date fields are not nil

--- a/rates.go
+++ b/rates.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/httpshopify/internal/http"
+import "github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
 // RateLimitDefault builds the default rate limit for the rest API.
 /*

--- a/rules.go
+++ b/rules.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // RuleDTOs represents Shopify rules in HTTP requests and responses.
 type RuleDTOs []RuleDTO

--- a/shipping.go
+++ b/shipping.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // ShippingLineDTOs is a collection of ShippingLine DTOs
 type ShippingLineDTOs []ShippingLineDTO

--- a/shop.go
+++ b/shop.go
@@ -3,9 +3,9 @@ package httpshopify
 import (
 	"fmt"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Shop is an http shopify shop

--- a/shop.go
+++ b/shop.go
@@ -13,6 +13,7 @@ type Shop struct {
 	orders            orderRepository
 	fulfillments      fulfillmentRepository
 	fulfillmentEvents fulfillmentEventRepository
+	fulfillmentOrders fulfillmentOrderRepository
 	variants          variantRepository
 	products          productRepository
 	inventoryLevels   inventoryLevelRepository
@@ -34,7 +35,7 @@ type Shop struct {
 */
 func NewShop(shop string, accessToken string) Shop {
 	return NewCustomShop(
-		fmt.Sprintf("https://%v.myshopify.com/admin/api/2021-04", shop),
+		fmt.Sprintf("https://%v.myshopify.com/admin/api/2022-07", shop),
 		accessToken,
 		IsDefault,
 	)
@@ -52,7 +53,7 @@ func NewShop(shop string, accessToken string) Shop {
 */
 func NewPlusShop(shop string, accessToken string) Shop {
 	return NewCustomShop(
-		fmt.Sprintf("https://%v.myshopify.com/admin/api/2021-04", shop),
+		fmt.Sprintf("https://%v.myshopify.com/admin/api/2022-07", shop),
 		accessToken,
 		IsPlus,
 	)
@@ -89,6 +90,7 @@ func NewCustomShop(url string, accessToken string, isPlus bool) Shop {
 		orders:            newOrderRepository(client, createURL),
 		fulfillments:      newFulfillmentRepository(client, createURL),
 		fulfillmentEvents: newFulfillmentEventRepository(client, createURL),
+		fulfillmentOrders: newFulfillmentOrderRepository(client, createURL),
 		variants:          newVariantRepository(client, createURL),
 		products:          newProductRepository(client, createURL),
 		inventoryLevels:   newInventoryLevelRepository(client, createURL),
@@ -113,6 +115,11 @@ func (shop Shop) Fulfillments() shopify.FulfillmentRepository {
 // FulfillmentEvents returns an HTTP implementation of a Shopify fulfillment event repository
 func (shop Shop) FulfillmentEvents() shopify.FulfillmentEventRepository {
 	return shop.fulfillmentEvents
+}
+
+// FulfillmentOrders returns an HTTP implementation of a Shopify fulfillment order repository
+func (shop Shop) FulfillmentOrders() shopify.FulfillmentOrderRepository {
+	return shop.fulfillmentOrders
 }
 
 // Variants returns an HTTP implementation of a Shopify variant repository

--- a/shop_test.go
+++ b/shop_test.go
@@ -3,8 +3,8 @@ package httpshopify_test
 import (
 	"testing"
 
-	"github.com/MOHC-LTD/httpshopify"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 func Test_ShopImplementsShopify(t *testing.T) {

--- a/tax.go
+++ b/tax.go
@@ -1,6 +1,6 @@
 package httpshopify
 
-import "github.com/MOHC-LTD/shopify"
+import "github.com/MOHC-LTD/shopify/v2"
 
 // TaxLineDTOs is a collection of tax line DTOs
 type TaxLineDTOs []TaxLineDTO

--- a/variants.go
+++ b/variants.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/http"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/http"
 
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 type variantRepository struct {

--- a/variants_test.go
+++ b/variants_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/MOHC-LTD/httpshopify/internal/assertions"
-	"github.com/MOHC-LTD/shopify"
+	"github.com/MOHC-LTD/httpshopify/v2/internal/assertions"
+	"github.com/MOHC-LTD/shopify/v2"
 )
 
 // Tests variant can be built when date fields are not nil


### PR DESCRIPTION
In Shopify API version `2022-07` (becomes minimum supported version 1st April), [several Admin APIs relating to order fulfillments](https://shopify.dev/docs/api/release-notes/2022-07#fulfillment-endpoints-removed-from-the-rest-admin-api) are being removed.

This PR amends the methods in `FulfillmentRepository` to reflect [those that remain](https://shopify.dev/docs/api/admin-rest/2022-07/resources/fulfillment) in `2022-07`. Creating a fulfillment now requires info from an order's `FulfillmentOrder`s and so the `FulfillmentOrderRepository` has been added with [methods to allow their fetching](https://shopify.dev/docs/api/admin-rest/2022-07/resources/fulfillmentorder).

Bumps the default Shopify API version to `2022-07`.

**WIP:** requires release of `shopify v2.0.0`

## Associated PRs
- [shopify](https://github.com/MOHC-LTD/shopify/pull/109)
- [mockshopify](https://github.com/MOHC-LTD/mockshopify/pull/39)