### PR TITLE
feat: allow client to retry queries

### DIFF
--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -77,10 +77,9 @@ func (c Client) Do(method string, url string, headers RequestHeaders, body io.Re
 	headers = c.AppendDefaultHeaders(headers)
 
 	var resp *http.Response
-	var req *http.Request
 
 	for i := 0; i < c.retryCount+1; i++ {
-		req, err = http.NewRequest(method, url, bytes.NewReader(requestBody))
+		req, err := http.NewRequest(method, url, bytes.NewReader(requestBody))
 		if err != nil {
 			return nil, ResponseHeaders{}, err
 		}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -114,7 +114,6 @@ func (c Client) Do(method string, url string, headers RequestHeaders, body io.Re
 		}
 
 		time.Sleep(waitTime)
-		req.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
 
 	if err != nil {

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -70,7 +69,7 @@ func (c Client) Do(method string, url string, headers RequestHeaders, body io.Re
 	var err error
 
 	if body != nil {
-		requestBody, err = ioutil.ReadAll(body)
+		requestBody, err = io.ReadAll(body)
 		if err != nil {
 			return nil, ResponseHeaders{}, err
 		}
@@ -104,7 +103,7 @@ func (c Client) Do(method string, url string, headers RequestHeaders, body io.Re
 
 			// Retry using exp backoff
 			time.Sleep(c.retryDuration(i))
-			req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+			req.Body = io.NopCloser(bytes.NewReader(requestBody))
 
 			continue
 		}
@@ -136,10 +135,10 @@ func (c Client) Do(method string, url string, headers RequestHeaders, body io.Re
 
 		time.Sleep(waitTime)
 
-		req.Body = ioutil.NopCloser(bytes.NewReader(requestBody))
+		req.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, ResponseHeaders{}, err
 	}

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -2,24 +2,31 @@ package http
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
+	"strconv"
+	"time"
 
 	"golang.org/x/time/rate"
 )
 
 // Client is a HTTP client
 type Client struct {
-	*http.Client
-	defaultHeaders RequestHeaders
-	limiter        *rate.Limiter
+	client            *http.Client
+	defaultHeaders    RequestHeaders
+	limiter           *rate.Limiter
+	RetryMaxDuration  time.Duration
+	RetryBaseDuration time.Duration
+	RetryCount        int
 }
 
 // NewClient builds a new HTTP client
 func NewClient(options ...Option) Client {
 	client := Client{
-		Client: &http.Client{},
+		client: &http.Client{},
 	}
 
 	for _, option := range options {
@@ -30,8 +37,8 @@ func NewClient(options ...Option) Client {
 }
 
 // AppendDefaultHeaders appends the default headers to the passed ones.
-func (client Client) AppendDefaultHeaders(headers RequestHeaders) RequestHeaders {
-	for _, header := range client.defaultHeaders {
+func (c Client) AppendDefaultHeaders(headers RequestHeaders) RequestHeaders {
+	for _, header := range c.defaultHeaders {
 		if !headers.Includes(header.Name) {
 			headers = append(headers, header)
 		}
@@ -41,13 +48,13 @@ func (client Client) AppendDefaultHeaders(headers RequestHeaders) RequestHeaders
 }
 
 // Do does a request
-func (client Client) Do(method string, url string, headers RequestHeaders, body io.Reader) ([]byte, ResponseHeaders, error) {
-	if client.limiter != nil {
+func (c Client) Do(method string, url string, headers RequestHeaders, body io.Reader) ([]byte, ResponseHeaders, error) {
+	if c.limiter != nil {
 		ctx := context.Background()
-		client.limiter.Wait(ctx)
+		c.limiter.Wait(ctx)
 	}
 
-	headers = client.AppendDefaultHeaders(headers)
+	headers = c.AppendDefaultHeaders(headers)
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -58,11 +65,49 @@ func (client Client) Do(method string, url string, headers RequestHeaders, body 
 		req.Header.Set(header.Name, header.Value)
 	}
 
-	resp, err := client.Client.Do(req)
-	if err != nil {
-		return nil, ResponseHeaders{}, err
+	var resp *http.Response
+	for i := 0; i < c.RetryCount+1; i++ {
+		resp, err = c.client.Do(req)
+
+		// Return early if error
+		if err != nil {
+			if i == c.RetryCount {
+				return nil, ResponseHeaders{}, err
+			}
+
+			continue
+		}
+
+		if resp != nil {
+			defer resp.Body.Close()
+		}
+
+		// Break if client config not set for retries or retries maxed out
+		if c.RetryCount == 0 || c.RetryCount == i {
+			break
+		}
+
+		// Break since we have a response
+		if resp.StatusCode != 429 && resp.StatusCode < 500 {
+			break
+		}
+
+		// Retry using Shopify's retry after duration if any
+		if retryAfterHeader := resp.Header.Get("Retry-After"); retryAfterHeader != "" {
+			retryAfter, _ := strconv.Atoi(retryAfterHeader)
+			waitTime := time.Duration(retryAfter) * time.Second
+			fmt.Printf("Rate limit was hit. Retry %d/%d starting in %v seconds\n", i+1, c.RetryCount, waitTime.Seconds())
+			time.Sleep(waitTime)
+
+			continue
+		}
+
+		// Retry defaulting to exponential backoff and jitter
+		waitTime := withExponentialBackOff(i, c.RetryBaseDuration, c.RetryMaxDuration)
+		withJitter(&waitTime)
+		fmt.Printf("Retry %d/%d starting in %v seconds.\n", i+1, c.RetryCount, waitTime.Seconds())
+		time.Sleep(waitTime)
 	}
-	defer resp.Body.Close()
 
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -75,4 +120,18 @@ func (client Client) Do(method string, url string, headers RequestHeaders, body 
 	}
 
 	return responseBody, ResponseHeaders{resp.Header}, nil
+}
+
+func withExponentialBackOff(retry int, base time.Duration, max time.Duration) time.Duration {
+	backoff := base * (1 << retry)
+
+	if backoff > max {
+		return max
+	}
+
+	return backoff
+}
+
+func withJitter(waitTime *time.Duration) {
+	*waitTime += time.Duration(rand.Float64() * float64(time.Second))
 }

--- a/internal/http/options.go
+++ b/internal/http/options.go
@@ -1,7 +1,31 @@
 package http
 
+import "time"
+
 // Option allows the client to be fully configurable
 type Option interface {
 	// configure configures the client with this option
 	configure(client *Client) error
+}
+
+type BackOffOptions struct {
+	retryCount        int
+	retryBaseDuration time.Duration
+	retryMaxDuration  time.Duration
+}
+
+func (option BackOffOptions) configure(client *Client) error {
+	client.retryCount = option.retryCount
+	client.retryBaseDuration = option.retryBaseDuration
+	client.retryMaxDuration = option.retryMaxDuration
+
+	return nil
+}
+
+func WithBackoffOptions(retryCount int, retryBaseDuration time.Duration, retryMaxDuration time.Duration) BackOffOptions {
+	return BackOffOptions{
+		retryCount,
+		retryBaseDuration,
+		retryMaxDuration,
+	}
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,23 @@
+package httpshopify
+
+import "time"
+
+type Options struct {
+	retryCount        int
+	retryBaseDuration time.Duration
+	retryMaxDuration  time.Duration
+}
+
+// OptionFunc is a function that sets options on the Options struct
+type OptionFunc func(*Options)
+
+// WithExponentialBackoff configures the client to use exponential backoff
+// on responses that indicate the request can be retried. Typically this is when
+// Shopify returns a 429 or 503 HTTP status code
+func WithExponentialBackoff(retryCount int, retryBaseDuration time.Duration, retryMaxDuration time.Duration) OptionFunc {
+	return func(o *Options) {
+		o.retryCount = retryCount
+		o.retryBaseDuration = retryBaseDuration
+		o.retryMaxDuration = retryMaxDuration
+	}
+}

--- a/options.go
+++ b/options.go
@@ -13,7 +13,7 @@ type OptionFunc func(*Options)
 
 // WithExponentialBackoff configures the client to use exponential backoff
 // on responses that indicate the request can be retried. Typically this is when
-// Shopify returns a 429 or 503 HTTP status code
+// Shopify returns a 429 or 5XX HTTP status code
 func WithExponentialBackoff(retryCount int, retryBaseDuration time.Duration, retryMaxDuration time.Duration) OptionFunc {
 	return func(o *Options) {
 		o.retryCount = retryCount

--- a/shop.go
+++ b/shop.go
@@ -101,9 +101,7 @@ func NewCustomShop(url string, accessToken string, isPlus bool, optionsFns ...Op
 		fn(&options)
 	}
 
-	client.RetryMaxDuration = options.retryMaxDuration
-	client.RetryBaseDuration = options.retryBaseDuration
-	client.RetryCount = options.retryCount
+	client.WithExponentialBackoff(options.retryCount, options.retryBaseDuration, options.retryMaxDuration)
 
 	return Shop{
 		orders:            newOrderRepository(client, createURL),

--- a/shop.go
+++ b/shop.go
@@ -86,22 +86,22 @@ func NewCustomShop(url string, accessToken string, isPlus bool, optionsFns ...Op
 		rateLimitOption = RateLimitDefault()
 	}
 
-	client := http.NewClient(
-		http.WithDefaultHeader("X-Shopify-Access-Token", accessToken),
-		http.WithDefaultHeader("Content-Type", "application/json"),
-		rateLimitOption,
-	)
-
-	createURL := func(endpoint string) string {
-		return fmt.Sprintf("%v/%v", url, endpoint)
-	}
-
+	// Apply OptionFuncs to Options
 	options := Options{}
 	for _, fn := range optionsFns {
 		fn(&options)
 	}
 
-	client.WithExponentialBackoff(options.retryCount, options.retryBaseDuration, options.retryMaxDuration)
+	client := http.NewClient(
+		http.WithDefaultHeader("X-Shopify-Access-Token", accessToken),
+		http.WithDefaultHeader("Content-Type", "application/json"),
+		rateLimitOption,
+		http.WithBackoffOptions(options.retryCount, options.retryBaseDuration, options.retryMaxDuration),
+	)
+
+	createURL := func(endpoint string) string {
+		return fmt.Sprintf("%v/%v", url, endpoint)
+	}
 
 	return Shop{
 		orders:            newOrderRepository(client, createURL),


### PR DESCRIPTION
Ability to retry failed queries multiple times when setting up the client by providing appropriate options. It will try to first use Shopify's 429 header for the wait time before making the next request or default to exp backoff.